### PR TITLE
DEVX-1284 - update to template title

### DIFF
--- a/software-templates/techdocs-template/template.yaml
+++ b/software-templates/techdocs-template/template.yaml
@@ -2,8 +2,8 @@ apiVersion: scaffolder.backstage.io/v1beta3
 kind: Template
 metadata:
     name: docs-template
-    title: DevHub Technical Documentation Template
-    description: Create a new repository for technical documentation
+    title: Create new technical documentation repo
+    description: Create a new repo for techdocs with required files to publish to DevHub
     tags:
         - techdocs
         - markdown


### PR DESCRIPTION
I've updated the copy for the V1 template here.

The V2 template hasn't been merged in yet, but the copy changes are in the branch: https://github.com/bcgov/devhub-templates/tree/DEVX1287-template-v2

They're also visible on dev since I'm just directly linking to my branch for testing purposes.