### PR TITLE
Generate year via macros plugin

### DIFF
--- a/software-templates/techdocs-template/skeleton/README.md
+++ b/software-templates/techdocs-template/skeleton/README.md
@@ -117,7 +117,7 @@ Please note that this project is released with a [Contributor Code of Conduct](C
 
 ## License
 
-© 2024 Province of British Columbia
+© {{ now().year }} Province of British Columbia
 
 Refer to the [LICENSE](LICENSE.md) file for more information.
 

--- a/software-templates/techdocs-template/skeleton/mkdocs.yml
+++ b/software-templates/techdocs-template/skeleton/mkdocs.yml
@@ -12,5 +12,6 @@ nav:
 plugins:
     - techdocs-core
     - git-revision-date-localized
+    - macros
 markdown_extensions:
     - md_in_html


### PR DESCRIPTION
Add macros plugin and generate copyright year in templates

**Waiting on devhub-techdocs-publish v0.1.1**