### PR TITLE
Devx 1354 - Transfer repository

### DIFF
--- a/software-templates/migrate-repo-to-enterprise/template.yaml
+++ b/software-templates/migrate-repo-to-enterprise/template.yaml
@@ -9,11 +9,13 @@ spec:
   type: service
 
   parameters:
-    - title: Specify repository details
+    - title: Transfer a repository
       required:
-        - repoUrl
+        - repoToTransfer
+        - owner
+        - destination
       properties:
-        repoUrl:
+        repoToTransfer:
           title: Repository to transfer
           type: string
           ui:field: RepoUrlPicker
@@ -27,24 +29,259 @@ spec:
               - github.com
             allowedOwners:
               - bcgov
+        destination:
+          title: Destination GitHub Organization
+          type: string
+          description: GitHub organization where the repo will be transferred to
+          enum: 
+            - bcgov-public
+          enumNames: 
+            - "bcgov-public"
+        owner:
+          title: GitHub team (required)
+          type: string
+          description: The team in the bcgov-public GitHub Organization that maintains the repo
+          ui:field: OwnerPicker
+          ui:options:
+              allowArbitraryValues: false
+              catalogFilter:
+                - kind: [ Group ]
+                  metadata.namespace: bcgov-public
+
+    - title: Provide information about your product/service/component
+      required:
+        - title
+        - description
+        - type
+        - lifecycle
+      properties:
+        title:
+          title: Title
+          type: string
+          description: A title for your product. For example, "Whizzbang Service".
+          ui:autofocus: true
+        description:
+          title: Description
+          type: string
+          description: A description for product/service/component.
+        # type field for catalog-info.yaml file, these values based on https://backstage.io/docs/features/software-catalog/descriptor-format/#spectype-required
+        type:
+          title: Product type
+          type: string
+          description: What your product/service/component provides.
+          enum: 
+            - documentation
+            - library
+            - service
+            - website
+            - other
+          enumNames: 
+            - "documentation - a standalone documentation repo"
+            - "library - a software library, such as an npm module or a Java library"
+            - "service - a backend service, typically exposing an API"
+            - "website - a website"
+            - "other"
+        # lifecycle field for catalog-info.yaml file, these values based on https://backstage.io/docs/features/software-catalog/descriptor-format/#speclifecycle-required
+        lifecycle:
+          title: Product lifecycle
+          type: string
+          description: What is the current state of the product
+          enum:
+            - experimental
+            - production
+            - deprecated
+          enumNames:
+            - "experimental - an experiment or early, non-production component"
+            - "production - an established, owned, maintained component"
+            - "deprecated - a component that is at the end of its lifecycle, and may disappear at a later point in time"
+      
+    - title: Provide information about your product (or service/component)
+      properties:
+        ministry:
+          title: Ministry (optional)
+          type: string
+          description: Name of the ministry associated with the product
+          enum:
+            - AF
+            - AG
+            - MCF
+            - CITZ
+            - ECC
+            - EMCR
+            - EMLI
+            - ENV
+            - FIN
+            - FOR
+            - HLTH
+            - HOUS
+            - IRR
+            - JEDI
+            - LBR
+            - MMHA
+            - MUNI
+            - PSFS
+            - PSSG
+            - SDPR
+            - TACS
+            - TRAN
+            - WLRS
+          enumNames:
+            - "Agriculture and Food"
+            - "Attorney General"
+            - "Children and Family Development"
+            - "Citizens' Services"
+            - "Education and Child Care"
+            - "Emergency Management and Climate Readiness"
+            - "Energy, Mines and Low Carbon Innovation"
+            - "Environment and Climate Change Strategy"
+            - "Finance"
+            - "Forests"
+            - "Health"
+            - "Housing"
+            - "Indigenous Relations & Reconciliation"
+            - "Jobs, Economic Development and Innovation"
+            - "Labour"
+            - "Mental Health and Addictions"
+            - "Municipal Affairs"
+            - "Post-Secondary Education and Future Skills"
+            - "Public Safety and Solicitor General"
+            - "Social Development and Poverty Reduction"
+            - "Tourism, Arts, Culture and Sport"
+            - "Transportation and Infrastructure"
+            - "Water, Land and Resource Stewardship"
+        product_name:
+          title: Product name (optional)
+          type: string
+          description: The name of the product
+        product_acronym:
+          title: Product acronym (optional)
+          type: string
+          description: An acronym used to identity the product, if there is one
+        product_owner:
+          title: Product owner (optional)
+          type: string
+          description: Name of the individual in the Product Owner role for the product
+        product_owner_email:
+          title: Product owner email (optional)
+          type: string
+          description: Email address of the individual in the Product Owner role for the product
+        hosting_platform:
+          title: Hosting platform (optional)
+          type: string
+          description: Name of the technical platform where the product is hosted
+          default: Private-Cloud-Openshift
+          enum:
+            - Amazon-Web-Services
+            - Google-Cloud-Platform
+            - Microsoft-Azure
+            - On-Premise-Physical
+            - On-Premise-Virtual
+            - Private-Cloud-Openshift
+            - Other
+            - Unknown
+            - Not-Applicable
+          enumNames:
+            - 'Amazon Web Service'
+            - 'Google Cloud Platform'
+            - 'Microsoft Azure'
+            - 'On-premise virtual infrastructure'
+            - 'On-premise physical infrastructure'
+            - 'OpenShift private cloud'
+            - "Other platform that isn't listed"
+            - "Not sure"
+            - "Not applicable"
 
   steps:
+    # Need to get the team id because the transfer repo endpoint accepts teamid not team slug
+    - id: get-team-id
+      name: 'Get team id'
+      action: 'http:backstage:request'
+      input:
+        method: 'GET'
+        path: 'proxy/github-api/orgs/${{ parameters.destination }}/teams/${{ parameters.owner | parseEntityRef | pick("name") }}'
+        logRequestPath: true
+        headers:
+          content-type: 'application/json'
+          Authorization: 'Bearer ${{ secrets.USER_OAUTH_TOKEN }}'
+
     - id: transfer-repo
       name: 'Transfer repo'
       action: 'http:backstage:request'
       input:
         method: 'POST'
-        path: 'proxy/github-api/repos/bcgov/${{ (parameters.repoUrl | parseRepoUrl).repo }}/transfer'
+        path: 'proxy/github-api/repos/bcgov/${{ (parameters.repoToTransfer | parseRepoUrl).repo }}/transfer'
         logRequestPath: true
         headers:
           content-type: 'application/json'
           Authorization: 'Bearer ${{ secrets.USER_OAUTH_TOKEN }}'
         body:
-          new_owner: bcgov-public
+          new_owner: ${{ parameters.destination }}
+          # Team will be set with read permissions. There is an api to set the permissions, but the
+          # user needs to have admin access to the repo already. 
+          # https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#add-or-update-team-repository-permissions
+          team_ids: [ '${{ steps["get-team-id"].output.body.id }}' ]
+
+    - id: create-catalog-file
+      name: Create catalog file.
+      action: catalog:write
+      input:
+        entity:
+          apiVersion: backstage.io/v1alpha1
+          kind: Component
+          metadata:
+            name: ${{ parameters.title | lower | replace(" ", "-") | replace("'", "") }}
+            title: ${{ parameters.title }}
+            description: ${{parameters.description }}
+            annotations:
+              github.com/project-slug: ${{ parameters.repoToTransfer | projectSlug }}
+              backstage.io/techdocs-ref: dir:.
+              bcgovpubcode.gov.bc.ca/ministry: ${{ parameters.ministry }}
+              bcgovpubcode.gov.bc.ca/product_name: ${{ parameters.product_name }}
+              bcgovpubcode.gov.bc.ca/product_acronym: ${{ parameters.product_acronym }}
+              bcgovpubcode.gov.bc.ca/product_owner: ${{ parameters.product_owner }}
+              developer.gov.bc.ca/source_template: "default/transfer-repo"
+          spec:
+              type: ${{ parameters.type }}  
+              lifecycle: ${{ parameters.lifecycle }}  
+              owner: ${{ parameters.owner | default("developer-experience", true) }}  
+
+    - id: wait-for-repo
+      name: waiting
+      action: debug:wait
+      input:
+        seconds: 5
+
+    - id: get-default-branch
+      name: 'Get default branch'
+      action: 'http:backstage:request'
+      input:
+        method: 'GET'
+        # repo has been moved so get it from new location
+        path: 'proxy/github-api/repos/${{ parameters.destination }}/${{ (parameters.repoToTransfer | parseRepoUrl).repo }}'
+        logRequestPath: true
+        headers:
+          content-type: 'application/json'
+          Authorization: 'Bearer ${{ secrets.USER_OAUTH_TOKEN }}'
+
+    - id: create-pr-meta-data
+      name: 'Create PR to add meta data'
+      action: publish:github:pull-request
+      input:
+        repoUrl: 'github.com?repo=${{ (parameters.repoToTransfer | parseRepoUrl).repo }}&owner=${{ parameters.destination }}'
+        title: "Add DevHub meta data"
+        branchName: "DevHub-publishing-pr-branch"
+        description: "This pull request will add DevHub meta data files"
+        token: ${{ secrets.USER_OAUTH_TOKEN }} 
+        targetBranchName: '${{ steps["get-team-id"].output.body.default_branch }}'
+        commitMessage: "Add DevHub meta data files"
+        update: true
 
   output:
+    links:
+      - title: Transferred repo
+        url: 'https://github.com/${{ parameters.destination }}/${{ (parameters.repoToTransfer | parseRepoUrl).repo }}'
     text:
       - title: The Response 
         content: |
-          Response code: ${{ steps['transfer-repo'].output.code }}
-          Response body: ${{ steps['transfer-repo'].output.body | dump}}
+          Repository was transferred 
+      

--- a/software-templates/migrate-repo-to-enterprise/template.yaml
+++ b/software-templates/migrate-repo-to-enterprise/template.yaml
@@ -33,6 +33,7 @@ spec:
           title: Destination GitHub Organization
           type: string
           description: GitHub organization where the repo will be transferred to.
+          default: bcgov-public
           enum: 
             - bcgov-public
           enumNames: 
@@ -66,9 +67,9 @@ spec:
           description: A description for product/service/component.
         # type field for catalog-info.yaml file, these values based on https://backstage.io/docs/features/software-catalog/descriptor-format/#spectype-required
         type:
-          title: Product type
+          title: Product category
           type: string
-          description: What your product/service/component provides.
+          description: Which categorization best matches the contents of the repository?
           enum: 
             - documentation
             - library
@@ -85,7 +86,7 @@ spec:
         lifecycle:
           title: Product lifecycle
           type: string
-          description: What is the current state of the product/service/component.
+          description: What is the current state of the product/service/component?
           enum:
             - experimental
             - production

--- a/software-templates/migrate-repo-to-enterprise/template.yaml
+++ b/software-templates/migrate-repo-to-enterprise/template.yaml
@@ -1,0 +1,50 @@
+apiVersion: scaffolder.backstage.io/v1beta3
+kind: Template
+metadata:
+  name: GitHub-Repo-Transfer
+  title: Transfer a repository between organizations
+  description: Transfer a repository from the bcgov GitHub organization to the bcgov-public GitHub enterprise organization
+spec:
+  owner: "developer-experience"
+  type: service
+
+  parameters:
+    - title: Specify repository details
+      required:
+        - repoUrl
+      properties:
+        repoUrl:
+          title: Repository to transfer
+          type: string
+          ui:field: RepoUrlPicker
+          ui:options:
+            requestUserCredentials: # this is super important - it causes the user to be prompted to log in to GitHub and/or authorize the required GH scopes.
+              secretsKey: USER_OAUTH_TOKEN
+              additionalScopes:
+                github:
+                  - workflow
+            allowedHosts:
+              - github.com
+            allowedOwners:
+              - bcgov
+
+  steps:
+    - id: transfer-repo
+      name: 'Transfer repo'
+      action: 'http:backstage:request'
+      input:
+        method: 'POST'
+        path: 'proxy/github-api/repos/bcgov/${{ (parameters.repoUrl | parseRepoUrl).repo }}/transfer'
+        logRequestPath: true
+        headers:
+          content-type: 'application/json'
+          Authorization: 'Bearer ${{ secrets.USER_OAUTH_TOKEN }}'
+        body:
+          new_owner: bcgov-public
+
+  output:
+    text:
+      - title: The Response 
+        content: |
+          Response code: ${{ steps['transfer-repo'].output.code }}
+          Response body: ${{ steps['transfer-repo'].output.body | dump}}

--- a/software-templates/migrate-repo-to-enterprise/template.yaml
+++ b/software-templates/migrate-repo-to-enterprise/template.yaml
@@ -32,7 +32,7 @@ spec:
         destination:
           title: Destination GitHub Organization
           type: string
-          description: GitHub organization where the repo will be transferred to
+          description: GitHub organization where the repo will be transferred to.
           enum: 
             - bcgov-public
           enumNames: 
@@ -40,7 +40,7 @@ spec:
         owner:
           title: GitHub team (required)
           type: string
-          description: The team in the bcgov-public GitHub Organization that maintains the repo
+          description: The team in the bcgov-public GitHub Organization that maintains the repo.
           ui:field: OwnerPicker
           ui:options:
               allowArbitraryValues: false
@@ -76,7 +76,7 @@ spec:
             - website
             - other
           enumNames: 
-            - "documentation - a standalone documentation repo"
+            - "documentation - a documentation repository"
             - "library - a software library, such as an npm module or a Java library"
             - "service - a backend service, typically exposing an API"
             - "website - a website"
@@ -85,7 +85,7 @@ spec:
         lifecycle:
           title: Product lifecycle
           type: string
-          description: What is the current state of the product
+          description: What is the current state of the product/service/component.
           enum:
             - experimental
             - production
@@ -95,12 +95,12 @@ spec:
             - "production - an established, owned, maintained component"
             - "deprecated - a component that is at the end of its lifecycle, and may disappear at a later point in time"
       
-    - title: Provide information about your product (or service/component)
+    - title: Provide information about your product/service/component
       properties:
         ministry:
           title: Ministry (optional)
           type: string
-          description: Name of the ministry associated with the product
+          description: Name of the ministry associated with the product.
           enum:
             - AF
             - AG
@@ -152,23 +152,23 @@ spec:
         product_name:
           title: Product name (optional)
           type: string
-          description: The name of the product
+          description: The name of the product.
         product_acronym:
           title: Product acronym (optional)
           type: string
-          description: An acronym used to identity the product, if there is one
+          description: An acronym used to identity the product, if there is one.
         product_owner:
           title: Product owner (optional)
           type: string
-          description: Name of the individual in the Product Owner role for the product
+          description: Name of the individual in the Product Owner role for the product.
         product_owner_email:
           title: Product owner email (optional)
           type: string
-          description: Email address of the individual in the Product Owner role for the product
+          description: Email address of the individual in the Product Owner role for the product.
         hosting_platform:
           title: Hosting platform (optional)
           type: string
-          description: Name of the technical platform where the product is hosted
+          description: Name of the technical platform where the product is hosted.
           default: Private-Cloud-Openshift
           enum:
             - Amazon-Web-Services
@@ -192,37 +192,19 @@ spec:
             - "Not applicable"
 
   steps:
-    # Need to get the team id because the transfer repo endpoint accepts teamid not team slug
-    - id: get-team-id
-      name: 'Get team id'
-      action: 'http:backstage:request'
+    - id: get-default-branch
+      name: Get repo's default branch
+      action: http:backstage:request
       input:
         method: 'GET'
-        path: 'proxy/github-api/orgs/${{ parameters.destination }}/teams/${{ parameters.owner | parseEntityRef | pick("name") }}'
+        path: 'proxy/github-api/repos/${{ (parameters.repoToTransfer | parseRepoUrl).owner }}/${{ (parameters.repoToTransfer | parseRepoUrl).repo }}'
         logRequestPath: true
         headers:
           content-type: 'application/json'
           Authorization: 'Bearer ${{ secrets.USER_OAUTH_TOKEN }}'
-
-    - id: transfer-repo
-      name: 'Transfer repo'
-      action: 'http:backstage:request'
-      input:
-        method: 'POST'
-        path: 'proxy/github-api/repos/bcgov/${{ (parameters.repoToTransfer | parseRepoUrl).repo }}/transfer'
-        logRequestPath: true
-        headers:
-          content-type: 'application/json'
-          Authorization: 'Bearer ${{ secrets.USER_OAUTH_TOKEN }}'
-        body:
-          new_owner: ${{ parameters.destination }}
-          # Team will be set with read permissions. There is an api to set the permissions, but the
-          # user needs to have admin access to the repo already. 
-          # https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#add-or-update-team-repository-permissions
-          team_ids: [ '${{ steps["get-team-id"].output.body.id }}' ]
 
     - id: create-catalog-file
-      name: Create catalog file.
+      name: Create catalog file
       action: catalog:write
       input:
         entity:
@@ -233,7 +215,7 @@ spec:
             title: ${{ parameters.title }}
             description: ${{parameters.description }}
             annotations:
-              github.com/project-slug: ${{ parameters.repoToTransfer | projectSlug }}
+              github.com/project-slug: ${{ parameters.destination }}/${{ (parameters.repoToTransfer | parseRepoUrl).repo }}
               backstage.io/techdocs-ref: dir:.
               bcgovpubcode.gov.bc.ca/ministry: ${{ parameters.ministry }}
               bcgovpubcode.gov.bc.ca/product_name: ${{ parameters.product_name }}
@@ -245,43 +227,74 @@ spec:
               lifecycle: ${{ parameters.lifecycle }}  
               owner: ${{ parameters.owner | default("developer-experience", true) }}  
 
-    - id: wait-for-repo
-      name: waiting
-      action: debug:wait
+    - id: pubcode
+      name: Create pubcode file
+      action: fetch:template
       input:
-        seconds: 5
+        url: ../../shared/pubcode
+        values:
+          name: ${{ parameters.product_name }}
+          description: ${{ parameters.description }}
+          ministry: ${{ parameters.ministry }}
+          product_name: ${{ parameters.product_name }}
+          product_acronym: ${{ parameters.product_acronym }}
+          product_owner: ${{ parameters.product_owner }}
+          hosting_platform: ${{ parameters.hosting_platform }}
 
-    - id: get-default-branch
-      name: 'Get default branch'
-      action: 'http:backstage:request'
+    # The PR is created on the repo before the transfer because there is a timing issue if the PR is created after the transfer
+    # The PR creation will fail because the transfer has not completed. So, create the PR on the repo before it is transferred
+    # The PR will be moved with the repo.
+    - id: create-pr-meta-data
+      name: Create PR to add meta data
+      action: publish:github:pull-request
+      input:
+        repoUrl: ${{ parameters.repoToTransfer }}
+        title: "Add DevHub meta data"
+        branchName: "DevHub-transfer-pr-branch"
+        description: "This pull request will add DevHub meta data files"
+        token: ${{ secrets.USER_OAUTH_TOKEN }} 
+        targetBranchName: '${{ steps["get-default-branch"].output.body.default_branch }}'
+        commitMessage: "Add DevHub meta data files"
+        update: true
+
+    # Need to get the team id because the transfer repo endpoint accepts teamid not team slug
+    - id: get-team-id
+      name: Get team id
+      action: http:backstage:request
       input:
         method: 'GET'
-        # repo has been moved so get it from new location
-        path: 'proxy/github-api/repos/${{ parameters.destination }}/${{ (parameters.repoToTransfer | parseRepoUrl).repo }}'
+        path: 'proxy/github-api/orgs/${{ parameters.destination }}/teams/${{ parameters.owner | parseEntityRef | pick("name") }}'
         logRequestPath: true
         headers:
           content-type: 'application/json'
           Authorization: 'Bearer ${{ secrets.USER_OAUTH_TOKEN }}'
 
-    - id: create-pr-meta-data
-      name: 'Create PR to add meta data'
-      action: publish:github:pull-request
+    - id: transfer-repo
+      name: Transfer repo
+      action: http:backstage:request
       input:
-        repoUrl: 'github.com?repo=${{ (parameters.repoToTransfer | parseRepoUrl).repo }}&owner=${{ parameters.destination }}'
-        title: "Add DevHub meta data"
-        branchName: "DevHub-publishing-pr-branch"
-        description: "This pull request will add DevHub meta data files"
-        token: ${{ secrets.USER_OAUTH_TOKEN }} 
-        targetBranchName: '${{ steps["get-team-id"].output.body.default_branch }}'
-        commitMessage: "Add DevHub meta data files"
-        update: true
+        method: 'POST'
+        path: 'proxy/github-api/repos/${{ (parameters.repoToTransfer | parseRepoUrl).owner }}/${{ (parameters.repoToTransfer | parseRepoUrl).repo }}/transfer'
+        logRequestPath: true
+        headers:
+          content-type: 'application/json'
+          Authorization: 'Bearer ${{ secrets.USER_OAUTH_TOKEN }}'
+        body:
+          new_owner: ${{ parameters.destination }}
+          team_ids: [ '${{ steps["get-team-id"].output.body.id }}' ]
 
   output:
     links:
-      - title: Transferred repo
+      - title: Transferred repository URL
         url: 'https://github.com/${{ parameters.destination }}/${{ (parameters.repoToTransfer | parseRepoUrl).repo }}'
     text:
-      - title: The Response 
-        content: |
-          Repository was transferred 
-      
+      - title: Next Steps
+        content: |         
+          The repository was [transferred to the ${{ parameters.destination }} organization](https://github.com/${{ parameters.destination }}/${{ (parameters.repoToTransfer | parseRepoUrl).repo }}). 
+
+          The [${{ parameters.owner | parseEntityRef | pick("name") }} team was assigned to the repository](https://github.com/${{ parameters.destination }}//${{ (parameters.repoToTransfer | parseRepoUrl).repo }}/settings/access), but its access will need to be updated.
+          
+          [PR-${{ steps["create-pr-meta-data"].output.pullRequestNumber }} was created](${{ steps["create-pr-meta-data"].output.remoteUrl }}) to add DevHub meta data to the repository. Please review and approve it.
+          
+          [Contact the Developer Experience Team](mailto:developer.experience@gov.bc.ca) if you have any questions or issues about the trasferred repository.
+ 

--- a/software-templates/techdocs-template-pr/template.yaml
+++ b/software-templates/techdocs-template-pr/template.yaml
@@ -34,8 +34,9 @@ spec:
                     ui:field: OwnerPicker
                     ui:options:
                         allowArbitraryValues: false
-                        allowedKinds:
-                            - Group
+                        catalogFilter:
+                            - kind: [ Group ]
+                              metadata.namespace: bcgov
         -   title: Provide information about your product (or service/component)
             properties:
                 ministry:

--- a/software-templates/techdocs-template/template.yaml
+++ b/software-templates/techdocs-template/template.yaml
@@ -34,8 +34,9 @@ spec:
                     ui:field: OwnerPicker
                     ui:options:
                         allowArbitraryValues: false
-                        allowedKinds:
-                            - Group
+                        catalogFilter:
+                            - kind: [ Group ]
+                              metadata.namespace: bcgov
         -   title: Provide information about your product (or service/component)
             properties:
                 ministry:


### PR DESCRIPTION
This PR does the following:

- Adds a new template that will allow transfer of a repo in the bcgov org to the bcgov-public org
- Updates the existing templates so only bcgov teams are displayed in the team drop down