### PR TITLE
Added bcgov-public as an allowed owner in the repo picker

### DIFF
--- a/software-templates/migrate-repo-to-enterprise/template.yaml
+++ b/software-templates/migrate-repo-to-enterprise/template.yaml
@@ -30,6 +30,7 @@ spec:
               - github.com
             allowedOwners:
               - bcgov
+              - bcgov-public
         destination:
           title: Destination GitHub Organization
           type: string


### PR DESCRIPTION
I noticed some issues when a user logged into GitHub from the template on the production site. It would give an error when publishing to bcgov-public. I've updated the repo picker to include 'bcgov-public' in the allowedOwners field. This should give the user's token the correct permissions.
