### PR TITLE
DEVX1420 - Create DevHub techdocs Wizard should set Team

### DIFF
--- a/software-templates/techdocs-template/template.yaml
+++ b/software-templates/techdocs-template/template.yaml
@@ -292,7 +292,7 @@ spec:
                 hasWiki: false
                 topics: [ "techdocs", "devhub" ]
                 collaborators:
-                    -   team: ${{ parameters.owner }}
+                    -   team: ${{ parameters.owner if parameters.owner }}
                         access: ${{ 'admin' if parameters.owner }}
     output:
         links:

--- a/software-templates/techdocs-template/template.yaml
+++ b/software-templates/techdocs-template/template.yaml
@@ -292,8 +292,8 @@ spec:
                 hasWiki: false
                 topics: [ "techdocs", "devhub" ]
                 collaborators:
-                    -   access: 'admin'
-                        team: ${{ parameters.owner }}
+                    -   team: ${{ parameters.owner if parameters.owner }}
+                        access: ${{ 'admin' if parameters.owner }}
     output:
         links:
             -   title: Repository

--- a/software-templates/techdocs-template/template.yaml
+++ b/software-templates/techdocs-template/template.yaml
@@ -292,7 +292,7 @@ spec:
                 hasWiki: false
                 topics: [ "techdocs", "devhub" ]
                 collaborators:
-                    -   team: ${{ parameters.owner if parameters.owner }}
+                    -   team: ${{ parameters.owner }}
                         access: ${{ 'admin' if parameters.owner }}
     output:
         links:

--- a/software-templates/techdocs-template/template.yaml
+++ b/software-templates/techdocs-template/template.yaml
@@ -291,6 +291,9 @@ spec:
                 hasProjects: false
                 hasWiki: false
                 topics: [ "techdocs", "devhub" ]
+                collaborators:
+                    -   access: 'admin'
+                        team: ${{ parameters.owner }}
     output:
         links:
             -   title: Repository


### PR DESCRIPTION
I modified the "Create a technical documentation repo" Wizard to add the GitHub Team to the new repo with Admin privileges, if supplied by the user.

The Wizard is on [test](https://test.developer.gov.bc.ca/create) if you want to check it out.