### PR TITLE
catalog-info: project slug missing owner

### DIFF
--- a/shared/common-yaml/catalog-info-component-action.yaml
+++ b/shared/common-yaml/catalog-info-component-action.yaml
@@ -20,7 +20,7 @@ input:
       title: ${{ parameters.title }}
       description: ${{parameters.description }}
       annotations:
-        github.com/project-slug: ${{ (parameters.repo | parseRepoUrl).organization }}/${{ (parameters.repo | parseRepoUrl).repo }}
+        github.com/project-slug: ${{ (parameters.repo | parseRepoUrl).owner }}/${{ (parameters.repo | parseRepoUrl).repo }}
         backstage.io/techdocs-ref: dir:.
         bcgovpubcode.gov.bc.ca/ministry: ${{ parameters.ministry }}
         bcgovpubcode.gov.bc.ca/product_name: ${{ parameters.product_name }}


### PR DESCRIPTION
The catalog-info field "github.com/project-slug" has a blank owner/org when used.

I switched it over to `(parameters.repo | parseRepoUrl).owner`