### PR TITLE
remove ".git" from broken links

### DIFF
--- a/software-templates/techdocs-template/template.yaml
+++ b/software-templates/techdocs-template/template.yaml
@@ -305,7 +305,7 @@ spec:
 
                     ## Here are the next steps you can take to get your documentation published in DevHub:
 
-                    * check out the contents of [your new repo](${{ steps.publish.output.remoteUrl }}) especially the [README file](${{ steps.publish.output.remoteUrl }}/README.md) and the [example home page](${{ steps.publish.output.remoteUrl }}/docs/index.md)
+                    * check out the contents of [your new repo](${{ steps.publish.output.remoteUrl }}) especially the [README file](${{ steps.publish.output.remoteUrl | replace(".git", "") }}/blob/main/README.md) and the [example home page](${{ steps.publish.output.remoteUrl | replace(".git", "") }}/blob/main/docs/index.md)
                     * check out [our Content Partner Guide](https://developer.gov.bc.ca) for info on "how this all works" and for creating your documentation
                     * add your additional pages to the repository
 


### PR DESCRIPTION
Several links on the final page of the techdocs repo wizard are broken. `steps.publish.output.remoteUrl` includes ".git" in the url. This causes issues when linking out to files in the new repo. This change just strips out the ".git" characters.