### PR TITLE
Devxt 2238: Add permission to workflow

### DIFF
--- a/shared/.github/workflows/publish.yaml
+++ b/shared/.github/workflows/publish.yaml
@@ -17,6 +17,8 @@ on:
 
 jobs:
     test_techdocs_build_job:
+        permissions:
+            contents: read
         runs-on: ubuntu-latest
 
         name: A job to build and publish techdocs content

--- a/shared/.github/workflows/publish.yaml
+++ b/shared/.github/workflows/publish.yaml
@@ -1,5 +1,6 @@
 name: Build TechDocs with DevHub TechDocs Publish Action
-
+permissions:
+    contents: read
 on:
     workflow_dispatch:
     push:
@@ -17,8 +18,6 @@ on:
 
 jobs:
     test_techdocs_build_job:
-        permissions:
-            contents: read
         runs-on: ubuntu-latest
 
         name: A job to build and publish techdocs content


### PR DESCRIPTION
This pull request includes a small change to the `shared/.github/workflows/publish.yaml` file. The change adds a `permissions` block specifying `contents: read` for the workflow.