### PR TITLE
Devx1961 - Add snowplow action

### DIFF
--- a/shared/common-yaml/catalog-info-component-action.yaml
+++ b/shared/common-yaml/catalog-info-component-action.yaml
@@ -27,7 +27,7 @@ input:
         bcgovpubcode.gov.bc.ca/product_description: ${{ parameters.description }}
         bcgovpubcode.gov.bc.ca/product_acronym: ${{ parameters.product_acronym }}
         bcgovpubcode.gov.bc.ca/product_owner: ${{ parameters.product_owner }}
-        bcgovpubcode.gov.bc.ca/hosting_platform: ${{ parameters.hosting_platform | default("OpenShift private cloud", true) }}
+        bcgovpubcode.gov.bc.ca/hosting_platform: ${{ parameters.hosting_platform | default("Private-Cloud-Openshift", true) }}
     spec:
         type: ${{ parameters.type }}  
         lifecycle: ${{ parameters.lifecycle }}  

--- a/software-templates/quickstart-openshift/template.yaml
+++ b/software-templates/quickstart-openshift/template.yaml
@@ -38,12 +38,10 @@ spec:
                         - backend-default
                         - backend-java
                         - backend-py
-                        - backend-go
                     enumNames:
                         - "JavaScript/TypeScript"
                         - "Java with Quarkus, Cloud Native"
                         - "Python with FastAPI"
-                        - "Go"
                 oc_server:
                     title: OC_SERVER
                     type: string
@@ -244,6 +242,17 @@ spec:
                     OC_NAMESPACE: ${{ parameters.oc_namespace }}
                 repoVariables:
                     OC_SERVER: ${{ parameters.oc_server }}
+        -   id: snowplow
+            name: Create Snowplow event
+            action: bcgov:snowplow:create
+            input:
+                name: quickstart-openshift
+                ministry: ${{ parameters.ministry }}
+                options:
+                    -   ${{ parameters.backend }}
+                    -   ${{ parameters.oc_server }}
+                platform: OpenShift private cloud
+                timeSaved: 60480 # backstage.io/time-saved in minutes
         -   id: setup-test-env
             name: Create test Environment
             action: github:environment:create

--- a/software-templates/quickstart-openshift/template.yaml
+++ b/software-templates/quickstart-openshift/template.yaml
@@ -251,8 +251,8 @@ spec:
                 options:
                     -   ${{ parameters.backend }}
                     -   ${{ parameters.oc_server }}
-                platform: OpenShift private cloud
-                timeSaved: 60480 # backstage.io/time-saved in minutes
+                platform: Private-Cloud-Openshift
+                timeSaved: 14400 # 6w at 40hr/w - backstage.io/time-saved in minutes
         -   id: setup-test-env
             name: Create test Environment
             action: github:environment:create


### PR DESCRIPTION
## Add snowplow action to Openshift quickstart

Adds a step to the Openshift quickstart Wizard to create a snowplow event w/ user input.

This change corresponds to [DevHub PR #239](https://github.com/bcgov/developer-portal/pull/239) which adds the `bcgov:snowplow:create` scaffolder action.

I also removed Go from the backend selection as it's no longer part of [quickstart-openshift-backends](https://github.com/bcgov/quickstart-openshift-backends)