### PR TITLE
Removed 'allowedHosts' property from publish:github action as it is not supported

### DIFF
--- a/software-templates/quickstart-openshift/template.yaml
+++ b/software-templates/quickstart-openshift/template.yaml
@@ -219,7 +219,6 @@ spec:
             name: Publish
             action: publish:github
             input:
-                allowedHosts: [ "github.com" ]
                 description: ${{ parameters.description }}
                 repoUrl: ${{ parameters.repo }}
                 token: ${{ secrets.USER_OAUTH_TOKEN }} # this causes the GitHub publish to be performed as the logged-in user and reduces the required permissions of the app itself.

--- a/software-templates/techdocs-template/template.yaml
+++ b/software-templates/techdocs-template/template.yaml
@@ -80,7 +80,6 @@ spec:
             name: Publish
             action: publish:github
             input:
-                allowedHosts: [ "github.com" ]
                 description: ${{ parameters.description }}
                 repoUrl: ${{ parameters.repo }}
                 token: ${{ secrets.USER_OAUTH_TOKEN }} # this causes the GitHub publish to be performed as the logged-in user and reduces the required permissions of the app itself.


### PR DESCRIPTION
Removed 'allowedHosts' property from publish:github action as it is not supported.

This is required for bcgov/developer-portal#241 as the scaffolder throws an error when the 'allowedHosts' property is in the template.
